### PR TITLE
Use src/server.js as entrypoint for npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node src/index.js",
+    "start": "node src/server.js",
     "coverage": "NODE_ENV=test istanbul cover _mocha"
   },
   "dependencies": {


### PR DESCRIPTION
This seems to have been refactored but package.json is still pointing to the removed file.