### PR TITLE
Implement getGroupByName (needed for speaking URLs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 addons:
   apt:
     sources:
-    - mongodb-3.2-precise
+    - mongodb-3.4-precise
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -32,6 +32,11 @@ module.exports.getOneGroupById = (id, callback) => {
     Group.findOne({_id: id}, callback);
 };
 
+// getByName
+module.exports.getOneGroupByName = (name, callback) => {
+    Group.findOne({name: name}, callback);
+};
+
 module.exports.getAllGroups = (callback) => {
     Group.find(callback);
 };

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -18,6 +18,20 @@ router.get('/getById/:id', (req, res) => {
     });
 });
 
+// Get Group by Name
+router.get('/getByName/:name', (req, res) => {
+    let name = req.params.name.toLowerCase();
+    Group.getOneGroupByName(name, (err, group) => {
+        if (err) {
+            res.json({success: false, msg: 'No Group found matching name: ' + name, error: err});
+        } else if (!group){
+            res.json({success: false, msg: 'No Group found matching name: ' + name});
+        } else {
+            res.json(group);
+        }
+    });
+});
+
 // Get all Groups
 router.get('/getGroups', (req, res) => {
     Group.getAllGroups((err, allGroups) => {
@@ -36,7 +50,7 @@ router.get('/getGroups', (req, res) => {
 router.post('/admin/create', (req, res) => {
     let groupToSave = new Group({
         type: req.body.type,
-        name: req.body.name,
+        name: req.body.name.toLowerCase(),
         picture: req.body.picture
     });
     Group.saveOneGroup(groupToSave, (err, savedGroup) => {

--- a/test/groups.js
+++ b/test/groups.js
@@ -128,6 +128,18 @@ describe('group', () => {
                 done();
             });
     });
+    it('/api/v1/group/getByName/:name', done => {
+        api.get('/api/v1/group/getByName/' + group2.name)
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .end((err, res) => {
+                expect(res.body._id).to.equal(group2._id);
+                expect(res.body.type).to.equal(group2.type);
+                expect(res.body.name).to.equal(group2.name);
+                done();
+            });
+    });
     it('/api/v1/group/getById/:id, wrong ID', done => {
         api.get('/api/v1/group/getById/' + '12345nananaBatmanIdToForceErr')
             .set('Accept', 'application/json')


### PR DESCRIPTION
Add new API endpoint for getByName
Always safe group names in lowercase

Needed for tageler/tageler-frontend#66